### PR TITLE
Fixed flaky-tests

### DIFF
--- a/src/test/java/eliasstar/gson/OptionalTypeAdapterTests.java
+++ b/src/test/java/eliasstar/gson/OptionalTypeAdapterTests.java
@@ -20,7 +20,9 @@ package eliasstar.gson;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Arrays;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -39,6 +41,12 @@ public final class OptionalTypeAdapterTests {
         gsonWithNulls = gson.newBuilder().serializeNulls().create();
     }
 
+    private String normalizeJson(String json) {
+        return Arrays.stream(json.replaceAll("[{}\"]", "").split(","))
+                .sorted()
+                .collect(Collectors.joining(","));
+    }
+
     @Test
     public void testOptionalSerialization() {
         var testObj = new OptionalTestObject();
@@ -47,11 +55,11 @@ public final class OptionalTypeAdapterTests {
 
         testObj.testOptional = Optional.of("test");
         assertEquals("{\"testOptional\":\"test\"}", gson.toJson(testObj));
-        assertEquals("{\"testString\":null,\"testOptional\":\"test\"}", gsonWithNulls.toJson(testObj));
+        assertEquals(normalizeJson("{\"testString\":null,\"testOptional\":\"test\"}"), normalizeJson(gsonWithNulls.toJson(testObj)));
 
         testObj.testString = "test";
-        assertEquals("{\"testString\":\"test\",\"testOptional\":\"test\"}", gson.toJson(testObj));
-        assertEquals("{\"testString\":\"test\",\"testOptional\":\"test\"}", gsonWithNulls.toJson(testObj));
+        assertEquals(normalizeJson("{\"testString\":\"test\",\"testOptional\":\"test\"}"), normalizeJson(gson.toJson(testObj)));
+        assertEquals(normalizeJson("{\"testString\":\"test\",\"testOptional\":\"test\"}"), normalizeJson(gsonWithNulls.toJson(testObj)));
 
         testObj.testOptional = Optional.empty();
         assertEquals("{\"testString\":\"test\"}", gson.toJson(testObj));

--- a/src/test/java/eliasstar/jsonrpc/ConnectionTests.java
+++ b/src/test/java/eliasstar/jsonrpc/ConnectionTests.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -149,6 +150,12 @@ public final class ConnectionTests {
         });
     }
 
+    private String normalizeJson(String json) {
+        return Arrays.stream(json.replaceAll("[{}\"]", "").split(","))
+                .sorted()
+                .collect(Collectors.joining(","));
+    }
+
     @Test
     public void testNotificationSending() {
         client.setResponse("test");
@@ -156,15 +163,15 @@ public final class ConnectionTests {
         var cases = new Executable[] {
                 () -> {
                     connection.sendNotification("test");
-                    assertEquals("{\"jsonrpc\":\"2.0\",\"method\":\"test\"}", client.getRequest());
+                    assertEquals(normalizeJson("{\"jsonrpc\":\"2.0\",\"method\":\"test\"}"), normalizeJson(client.getRequest()));
                 },
                 () -> {
                     connection.sendNotification("test", new JsonArray());
-                    assertEquals("{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"params\":[]}", client.getRequest());
+                    assertEquals(normalizeJson("{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"params\":[]}"), normalizeJson(client.getRequest()));
                 },
                 () -> {
                     connection.sendNotification("test", new JsonObject());
-                    assertEquals("{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"params\":{}}", client.getRequest());
+                    assertEquals(normalizeJson("{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"params\":{}}"), normalizeJson(client.getRequest()));
                 }
         };
 

--- a/src/test/java/eliasstar/jsonrpc/objects/NotificationTests.java
+++ b/src/test/java/eliasstar/jsonrpc/objects/NotificationTests.java
@@ -27,6 +27,9 @@ import org.junit.jupiter.api.Test;
 
 import eliasstar.utils.GsonProvider;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 public final class NotificationTests {
 
     private static Gson gson;
@@ -38,14 +41,20 @@ public final class NotificationTests {
         gsonWithNulls = GsonProvider.gsonWithNulls();
     }
 
+    private String normalizeJson(String json) {
+        return Arrays.stream(json.replaceAll("[{}\"]", "").split(","))
+                .sorted()
+                .collect(Collectors.joining(","));
+    }
+
     @Test
     public void testNotificationSerialization() {
         var json = "{\"jsonrpc\":\"2.0\",\"method\":\"test\"}";
         var obj = new Notification("test");
 
         assertAll(
-                () -> assertEquals(json, gson.toJson(obj)),
-                () -> assertEquals(json, gsonWithNulls.toJson(obj)));
+                () -> assertEquals(normalizeJson(json), normalizeJson(gson.toJson(obj))),
+                () -> assertEquals(normalizeJson(json), normalizeJson(gsonWithNulls.toJson(obj))));
     }
 
     @Test

--- a/src/test/java/eliasstar/jsonrpc/objects/RequestTests.java
+++ b/src/test/java/eliasstar/jsonrpc/objects/RequestTests.java
@@ -21,7 +21,9 @@ package eliasstar.jsonrpc.objects;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.stream.Collectors;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -45,6 +47,12 @@ public final class RequestTests {
         gsonWithNulls = GsonProvider.gsonWithNulls();
     }
 
+    private String normalizeJson(String json) {
+        return Arrays.stream(json.replaceAll("[{}\"]", "").split(","))
+                .sorted()
+                .collect(Collectors.joining(","));
+    }
+
     @Test
     public void testRequestIdSerialization() {
         var cases = new HashMap<String, Request>();
@@ -54,8 +62,8 @@ public final class RequestTests {
         cases.put("{\"jsonrpc\":\"2.0\",\"id\":null,\"method\":\"test\"}", new Request(NullId.instance(), "test", null));
 
         cases.forEach((e, a) -> assertAll(
-                () -> assertEquals(e, gson.toJson(a)),
-                () -> assertEquals(e, gsonWithNulls.toJson(a))));
+                () -> assertEquals(normalizeJson(e), normalizeJson(gson.toJson(a))),
+                () -> assertEquals(normalizeJson(e), normalizeJson(gsonWithNulls.toJson(a)))));
     }
 
     @Test
@@ -76,15 +84,15 @@ public final class RequestTests {
         arrParams.add(0);
         arrParams.add(JsonNull.INSTANCE);
 
-        assertEquals("{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"params\":[\"test\",0,null]}", gson.toJson(new Notification("test", arrParams)));
+        assertEquals(normalizeJson("{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"params\":[\"test\",0,null]}"), normalizeJson(gson.toJson(new Notification("test", arrParams))));
 
         var objParams = new JsonObject();
         objParams.addProperty("string", "test");
         objParams.addProperty("number", 0);
         objParams.add("null", JsonNull.INSTANCE);
 
-        assertEquals("{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"params\":{\"string\":\"test\",\"number\":0}}", gson.toJson(new Notification("test", objParams)));
-        assertEquals("{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"params\":{\"string\":\"test\",\"number\":0,\"null\":null}}", gsonWithNulls.toJson(new Notification("test", objParams)));
+        assertEquals(normalizeJson("{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"params\":{\"string\":\"test\",\"number\":0}}"), normalizeJson(gson.toJson(new Notification("test", objParams))));
+        assertEquals(normalizeJson("{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"params\":{\"string\":\"test\",\"number\":0,\"null\":null}}"), normalizeJson(gsonWithNulls.toJson(new Notification("test", objParams))));
     }
 
     @Test


### PR DESCRIPTION
### Issue:
The following tests fail due to an assertCheck between two JSON Strings.

1. [testOptionalSerialization()](https://github.com/harshith2000/JsonRpc4J/blob/6d7f58389e86efa4f44cc8906a7d1963b7f208b9/src/test/java/eliasstar/gson/OptionalTypeAdapterTests.java#L43)
2. [testNotificationSending()](https://github.com/harshith2000/JsonRpc4J/blob/6d7f58389e86efa4f44cc8906a7d1963b7f208b9/src/test/java/eliasstar/jsonrpc/ConnectionTests.java#L153)
3. [testNotificationSerialization()](https://github.com/harshith2000/JsonRpc4J/blob/6d7f58389e86efa4f44cc8906a7d1963b7f208b9/src/test/java/eliasstar/jsonrpc/objects/NotificationTests.java#L42)
4. [testRequestIdSerialization()](https://github.com/harshith2000/JsonRpc4J/blob/6d7f58389e86efa4f44cc8906a7d1963b7f208b9/src/test/java/eliasstar/jsonrpc/objects/RequestTests.java#L49)
5. [testRequestParamsSerialization()](https://github.com/harshith2000/JsonRpc4J/blob/6d7f58389e86efa4f44cc8906a7d1963b7f208b9/src/test/java/eliasstar/jsonrpc/objects/RequestTests.java#L73)

In JSON, the order of keys is not guaranteed to be preserved, and it's common for JSON serializers to output keys in a different order than they were input or defined.

### Fix:

To fix these errors, we can adjust the test to compare the JSON objects without relying on the order of the keys. 
- Normalize the JSON strings by parsing and sorting the key-value pairs.
- Compare the normalized JSON strings in your assertions.

### Steps to reproduce the behavior:
I used an open-source tool called [NonDex](https://github.com/TestingResearchIllinois/NonDex) to detect the assumption by shuffling the order of returned exception types.
Running the following commands will test the aforementioned operation

**Clone the Repo**
```
https://github.com/EliasStar/JsonRpc4J.git
```
**Compile the project**
```
mvn install -am -DskipTests
```
**(Optional) Run the unit test**
```
mvn test
```
**Run the unit test using NonDex**
```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex
```

### Stack trace for additional information:
```
[ERROR] Failures: 
[ERROR]   OptionalTypeAdapterTests.testOptionalSerialization:50 expected: <{"testString":null,"testOptional":"test"}> but was: <{"testOptional":"test","testString":null}>
[ERROR]   ConnectionTests.testNotificationSending:171 Multiple Failures (2 failures)
        org.opentest4j.AssertionFailedError: expected: <{"jsonrpc":"2.0","method":"test","params":[]}> but was: <{"params":[],"jsonrpc":"2.0","method":"test"}>
        org.opentest4j.AssertionFailedError: expected: <{"jsonrpc":"2.0","method":"test","params":{}}> but was: <{"params":{},"jsonrpc":"2.0","method":"test"}>
[ERROR]   NotificationTests.testNotificationSerialization:46 Multiple Failures (2 failures)
        org.opentest4j.AssertionFailedError: expected: <{"jsonrpc":"2.0","method":"test"}> but was: <{"method":"test","jsonrpc":"2.0"}>
        org.opentest4j.AssertionFailedError: expected: <{"jsonrpc":"2.0","method":"test"}> but was: <{"method":"test","jsonrpc":"2.0"}>
[ERROR]   RequestTests.testRequestIdSerialization:56->lambda$testRequestIdSerialization$2:56 Multiple Failures (2 failures)
        org.opentest4j.AssertionFailedError: expected: <{"jsonrpc":"2.0","id":"test","method":"test"}> but was: <{"jsonrpc":"2.0","method":"test","id":"test"}>
        org.opentest4j.AssertionFailedError: expected: <{"jsonrpc":"2.0","id":"test","method":"test"}> but was: <{"method":"test","id":"test","jsonrpc":"2.0"}>
[ERROR]   RequestTests.testRequestParamsSerialization:79 expected: <{"jsonrpc":"2.0","method":"test","params":["test",0,null]}> but was: <{"params":["test",0,null],"method":"test","jsonrpc":"2.0"}>

```